### PR TITLE
fix: Reference parameters are wrong

### DIFF
--- a/XmlDocumentationNameGetter/Artees/Tools/XmlDocumentationNameGetter/XmlDocumentationNameGetterExtensions.cs
+++ b/XmlDocumentationNameGetter/Artees/Tools/XmlDocumentationNameGetter/XmlDocumentationNameGetterExtensions.cs
@@ -63,7 +63,7 @@ namespace Artees.Tools.XmlDocumentationNameGetter
             var genericArgs = GetGenericTypeArgsString(type);
             var f = type.FullName ?? $"{type.Namespace}.{type.Name}";
             var g = string.IsNullOrEmpty(genericArgs) ? f : f.Split('`')[0];
-            var typeName = g.Replace('+', '.');
+            var typeName = g.Replace('+', '.').Replace("&", "@");
             return $"{typeName}{genericArgs}";
         }
 

--- a/XmlDocumentationNameGetterTestAssembly/Class.cs
+++ b/XmlDocumentationNameGetterTestAssembly/Class.cs
@@ -70,6 +70,23 @@ namespace XmlDocumentationNameGetterTestAssembly
         /// <summary>
         /// Method summary
         /// </summary>
+        /// <param name="arg">Out argument</param>
+        public void MethodOutParameter(out int arg)
+        {
+            arg = 0;
+        }
+
+        /// <summary>
+        /// Method summary
+        /// </summary>
+        /// <param name="arg">Ref argument</param>
+        public void MethodRefParameter(ref int arg)
+        {
+        }
+
+        /// <summary>
+        /// Method summary
+        /// </summary>
         public void Method(Tuple<int, int> arg)
         {
         }


### PR DESCRIPTION
Hello Artees,
in the XML files, '&' cannot be used, which is used for [reference types ](https://learn.microsoft.com/de-de/dotnet/api/system.type.isbyref?view=net-7.0). It must be replaced by '@'.
Please merge this branch into your repository.