### PR TITLE
fix: Generic reference parameters are wrong

### DIFF
--- a/XmlDocumentationNameGetter/Artees/Tools/XmlDocumentationNameGetter/XmlDocumentationNameGetterExtensions.cs
+++ b/XmlDocumentationNameGetter/Artees/Tools/XmlDocumentationNameGetter/XmlDocumentationNameGetterExtensions.cs
@@ -59,11 +59,12 @@ namespace Artees.Tools.XmlDocumentationNameGetter
 
         private static string GetTypeName(Type type)
         {
+            if (type.IsByRef) return GetTypeName(type.GetElementType()) + "@";
             if (type.IsGenericParameter) return GetGenericTypeName(type);
             var genericArgs = GetGenericTypeArgsString(type);
             var f = type.FullName ?? $"{type.Namespace}.{type.Name}";
             var g = string.IsNullOrEmpty(genericArgs) ? f : f.Split('`')[0];
-            var typeName = g.Replace('+', '.').Replace("&", "@");
+            var typeName = g.Replace('+', '.');
             return $"{typeName}{genericArgs}";
         }
 

--- a/XmlDocumentationNameGetterTestAssembly/GenericClass.cs
+++ b/XmlDocumentationNameGetterTestAssembly/GenericClass.cs
@@ -63,6 +63,41 @@ namespace XmlDocumentationNameGetterTestAssembly
         {
         }
         
+
+        /// <summary>
+        /// Method summary
+        /// </summary>
+        public void Method(out T arg)
+        {
+            arg = default(T);
+        }
+
+        /// <summary>
+        /// Method summary
+        /// </summary>
+        public void MethodGenericOut<TMethod>(out TMethod arg)
+        {
+            arg = default(TMethod);
+        }
+
+        /// <summary>
+        /// Method summary
+        /// </summary>
+        public void MethodGenericOut<TMethod>(out TMethod arg1, out T arg2)
+        {
+            arg1 = default(TMethod);
+            arg2 = default(T);
+        }
+
+        /// <summary>
+        /// Method summary
+        /// </summary>
+        public void MethodGenericRef<TMethod>(ref TMethod arg1, ref T arg2)
+        {
+            arg1 = default(TMethod);
+            arg2 = default(T);
+        }
+
         /// <summary>
         /// Equals summary
         /// </summary>


### PR DESCRIPTION
Hello Artees,
generic reference type parameters (e.g. void Method<T>(out T arg1, ref T arg2) aren't converted correct. I fixed this issue.
Please merge this branch into your repository.